### PR TITLE
Add instructions to run rmf-web according to new run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,8 +425,23 @@ pnpm install
 
 #### [Launching for development](https://github.com/open-rmf/rmf-web#launching-for-development)
 
-Source Open-RMF and launch the demo dashboard in development mode,
+Source Open-RMF and launch the demo dashboard in development mode. To do this, first we need to start the api-server:
 
+```shell
+# For binary installation
+source /opt/ros/jazzy/setup.bash
+
+# For source build: source the rmf_ws you installed in the steps above
+source /path/to/your/rmf/workspace/install/setup.bash
+
+cd path/to/your/rmf-web
+cd packages/api-server
+pnpm start
+```
+
+This starts up the API server (by default at port 8000) which sets up endpoints to communicate with an Open-RMF deployment, as well as begin compilation of the demo dashboard. 
+
+Next, we start the rmf-dashboard-framework. To do this, open a new terminal and do the following:
 ```shell
 # For binary installation
 source /opt/ros/jazzy/setup.bash
@@ -439,7 +454,7 @@ cd packages/rmf-dashboard-framework
 pnpm start
 ```
 
-This starts up the API server (by default at port 8000) which sets up endpoints to communicate with an Open-RMF deployment, as well as begin compilation of the demo dashboard. Once completed, it can be viewed at [localhost:5173](http://localhost:5173/).
+Once completed, the dashboard can be viewed at [localhost:5173](http://localhost:5173/).
 
 If presented with a login screen, use `user=admin password=admin`.
 


### PR DESCRIPTION
Add instructions to run rmf-web according to [this new update](https://github.com/open-rmf/rmf-web/pull/1052) and the [new instructions](https://github.com/open-rmf/rmf-web?tab=readme-ov-file#launching-for-development).

The main changes are:
1) First, we need to run the api-server: 
```shell
source /path/to/your/rmf/workspace/install/setup.bash
cd path/to/your/rmf-web
cd packages/api-server
pnpm start
```
2) Next, we run the rmf-dashboard-framework:
```shell
source /path/to/your/rmf/workspace/install/setup.bash
cd path/to/your/rmf-web
cd packages/rmf-dashboard-framework
pnpm start
```